### PR TITLE
Fix typos in utilities and error codes

### DIFF
--- a/app/schema/apperror/errcode/error_code.go
+++ b/app/schema/apperror/errcode/error_code.go
@@ -1,7 +1,7 @@
 package errcode
 
 const (
-	TPYE_ASSERTION_ERROR = "TYPE_ASSETION_ERROR"
+	TYPE_ASSERTION_ERROR = "TYPE_ASSERTION_ERROR"
 	USER_EXIST           = "USER_EXIST"
 	USER_NOT_FOUND       = "USER_NOT_FOUND"
 	INVALID_TOKEN        = "INVALID_TOKEN"
@@ -15,7 +15,7 @@ var code2Message = map[string]string{
 	INVALID_TOKEN:        "Token 驗證失敗",
 	EXPIRED_TOKEN:        "Token 過期",
 	BAD_REQUEST:          "輸入錯誤",
-	TPYE_ASSERTION_ERROR: "內部推斷型態錯誤",
+	TYPE_ASSERTION_ERROR: "內部推斷型態錯誤",
 }
 
 func Message(code string) string {

--- a/app/services/auth/auth.go
+++ b/app/services/auth/auth.go
@@ -16,10 +16,10 @@ import (
 
 type AuthService struct {
 	userRepo      UserRepo.IGetUserByMail
-	passwordUtils utils.IPasswrodUtils
+	passwordUtils utils.IPasswordUtils
 }
 
-func NewAuthService(userRepo *UserRepo.UserRepo, passwordUtils utils.IPasswrodUtils) *AuthService {
+func NewAuthService(userRepo *UserRepo.UserRepo, passwordUtils utils.IPasswordUtils) *AuthService {
 	return &AuthService{
 		userRepo:      userRepo,
 		passwordUtils: passwordUtils,

--- a/app/services/user/user_impl.go
+++ b/app/services/user/user_impl.go
@@ -18,11 +18,11 @@ import (
 
 type UserService struct {
 	userRepo      UserRepo.IUserRepository
-	passwordUtils utils.IPasswrodUtils
+	passwordUtils utils.IPasswordUtils
 	objectCreator imongo.IObjectIdCreator
 }
 
-func NewUserService(userRepo UserRepo.IUserRepository, passwordUtils utils.IPasswrodUtils, objectCreator imongo.IObjectIdCreator) *UserService {
+func NewUserService(userRepo UserRepo.IUserRepository, passwordUtils utils.IPasswordUtils, objectCreator imongo.IObjectIdCreator) *UserService {
 	return &UserService{
 		userRepo:      userRepo,
 		passwordUtils: passwordUtils,

--- a/app/testutils/password_utils.go
+++ b/app/testutils/password_utils.go
@@ -6,20 +6,20 @@ type MockPasswordUtils struct {
 	mock.Mock
 }
 
-// GenerateSalt implements utils.IPasswrodUtils.
+// GenerateSalt implements utils.IPasswordUtils.
 func (m *MockPasswordUtils) GenerateSalt(length int) (string, error) {
 	args := m.Called(length)
 
 	return args.String(0), args.Error(1)
 }
 
-// HashPassword implements utils.IPasswrodUtils.
+// HashPassword implements utils.IPasswordUtils.
 func (m *MockPasswordUtils) HashPassword(password string, salt string) (string, error) {
 	args := m.Called(password, salt)
 	return args.String(0), args.Error(1)
 }
 
-// VerifyPassword implements utils.IPasswrodUtils.
+// VerifyPassword implements utils.IPasswordUtils.
 func (m *MockPasswordUtils) VerifyPassword(hashedPassword string, password string, salt string) bool {
 	args := m.Called(hashedPassword, password, salt)
 	return args.Bool(0)

--- a/app/utils/reqcontext/context_key.go
+++ b/app/utils/reqcontext/context_key.go
@@ -20,7 +20,7 @@ func GetUserInfo(c *gin.Context) (userInfo AuthSchema.JWTUserInfo, err error) {
 	}
 	userInfo, ok = userInfoAny.(auth.JWTUserInfo)
 	if !ok {
-		err = apperror.New(http.StatusInternalServerError, errcode.TPYE_ASSERTION_ERROR, nil)
+		err = apperror.New(http.StatusInternalServerError, errcode.TYPE_ASSERTION_ERROR, nil)
 		return
 	}
 	return

--- a/app/utils/security.go
+++ b/app/utils/security.go
@@ -7,7 +7,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-type IPasswrodUtils interface {
+type IPasswordUtils interface {
 	GenerateSalt(length int) (string, error)
 	HashPassword(password string, salt string) (string, error)
 	VerifyPassword(hashedPassword string, password string, salt string) bool


### PR DESCRIPTION
## Summary
- rename `IPasswrodUtils` interface to `IPasswordUtils`
- rename `TPYE_ASSERTION_ERROR` constant to `TYPE_ASSERTION_ERROR`
- update all usages of the renamed interface and constant

## Testing
- `go test ./...` *(fails: access to proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687b036c6cac8329890026bbc1661bab