### PR TITLE
Add more unit tests

### DIFF
--- a/app/config/environment_test.go
+++ b/app/config/environment_test.go
@@ -1,0 +1,15 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetEnvOrDefault(t *testing.T) {
+	os.Setenv("TEST_ENV", "value")
+	defer os.Unsetenv("TEST_ENV")
+	assert.Equal(t, "value", getEnvOrDefault("TEST_ENV", "default"))
+	assert.Equal(t, "default", getEnvOrDefault("NOT_SET", "default"))
+}

--- a/app/services/auth/auth_test.go
+++ b/app/services/auth/auth_test.go
@@ -1,0 +1,49 @@
+package auth
+
+import (
+	"context"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"testing"
+	UserModel "wentee/blog/app/model/mongodb/user"
+	"wentee/blog/app/schema/auth"
+	"wentee/blog/app/testutils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// mockUserRepo implements userRepo interface
+type mockUserRepo struct{ mock.Mock }
+
+func (m *mockUserRepo) GetUserByEmail(ctx context.Context, email string, opts ...*options.FindOneOptions) (*UserModel.UserDocument, error) {
+	args := m.Called(testutils.AppendCallArgs([]any{ctx, email}, opts)...)
+	return args.Get(0).(*UserModel.UserDocument), args.Error(1)
+}
+
+func TestTryLogin(t *testing.T) {
+	repo := new(mockUserRepo)
+	pass := new(testutils.MockPasswordUtils)
+	svc := &AuthService{userRepo: repo, passwordUtils: pass}
+
+	user := &UserModel.UserDocument{Id: primitive.NewObjectID(), Email: "a@b.c", Username: "u", Password: "hash", Salt: "s"}
+	repo.On("GetUserByEmail", mock.Anything, "a@b.c").Return(user, nil)
+	pass.On("VerifyPassword", user.Password, "pw", user.Salt).Return(true)
+
+	token, err := svc.TryLogin(context.TODO(), &auth.LoginInfo{Email: "a@b.c", Password: "pw"})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, token)
+}
+
+func TestTryLogin_WrongPassword(t *testing.T) {
+	repo := new(mockUserRepo)
+	pass := new(testutils.MockPasswordUtils)
+	svc := &AuthService{userRepo: repo, passwordUtils: pass}
+
+	user := &UserModel.UserDocument{Id: primitive.NewObjectID(), Password: "hash", Salt: "s"}
+	repo.On("GetUserByEmail", mock.Anything, "a@b.c").Return(user, nil)
+	pass.On("VerifyPassword", user.Password, "pw", user.Salt).Return(false)
+
+	_, err := svc.TryLogin(context.TODO(), &auth.LoginInfo{Email: "a@b.c", Password: "pw"})
+	assert.Error(t, err)
+}

--- a/app/services/post/post_test.go
+++ b/app/services/post/post_test.go
@@ -8,10 +8,11 @@ import (
 	"wentee/blog/app/schema/basemodel"
 	PostSchema "wentee/blog/app/schema/post"
 
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"time"
 )
 
 type mockPostRepo struct{ mock.Mock }
@@ -62,7 +63,18 @@ func TestPostService_ListPosts(t *testing.T) {
 	svc := &PostService{postRepo: repo}
 	query := &basemodel.BaseQuery{Skip: 0, Limit: 1}
 	oid := primitive.NewObjectID()
-	repo.On("ListPosts", mock.Anything, query).Return(int64(1), []PostModel.PostWithCreatorDocument{{Id: oid, Title: "t", Creator: UserModel.UserDocument{Id: oid, Username: "u"}}}, nil)
+	repo.On("ListPosts", mock.Anything, query).Return(int64(1), []PostModel.PostWithCreatorDocument{
+		{
+			PostDocument: PostModel.PostDocument{
+				Id:    oid,
+				Title: "t",
+			},
+			Creator: UserModel.UserDocument{
+				Id:       oid,
+				Username: "u",
+			},
+		},
+	}, nil)
 
 	total, posts, err := svc.ListPosts(context.TODO(), query)
 	assert.NoError(t, err)

--- a/app/services/post/post_test.go
+++ b/app/services/post/post_test.go
@@ -1,0 +1,93 @@
+package post
+
+import (
+	"context"
+	"testing"
+	PostModel "wentee/blog/app/model/mongodb/post"
+	UserModel "wentee/blog/app/model/mongodb/user"
+	"wentee/blog/app/schema/basemodel"
+	PostSchema "wentee/blog/app/schema/post"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"time"
+)
+
+type mockPostRepo struct{ mock.Mock }
+
+func (m *mockPostRepo) CreatePost(ctx context.Context, postCreate *PostSchema.PostCreate, createdBy *primitive.ObjectID) error {
+	args := m.Called(ctx, postCreate, createdBy)
+	return args.Error(0)
+}
+func (m *mockPostRepo) ListPosts(ctx context.Context, query *basemodel.BaseQuery) (int64, []PostModel.PostWithCreatorDocument, error) {
+	args := m.Called(ctx, query)
+	return args.Get(0).(int64), args.Get(1).([]PostModel.PostWithCreatorDocument), args.Error(2)
+}
+func (m *mockPostRepo) GetPostById(ctx context.Context, id primitive.ObjectID) (PostModel.PostWithCreatorDocument, error) {
+	args := m.Called(ctx, id)
+	return args.Get(0).(PostModel.PostWithCreatorDocument), args.Error(1)
+}
+func (m *mockPostRepo) UpdatePostById(ctx context.Context, id primitive.ObjectID, updateData *PostSchema.PostUpdate) error {
+	args := m.Called(ctx, id, updateData)
+	return args.Error(0)
+}
+func (m *mockPostRepo) DeletePostById(ctx context.Context, id primitive.ObjectID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func TestPostService_CreatePost(t *testing.T) {
+	repo := new(mockPostRepo)
+	svc := &PostService{postRepo: repo}
+	create := &PostSchema.PostCreate{Title: "t"}
+	oid := primitive.NewObjectID()
+	repo.On("CreatePost", mock.Anything, create, &oid).Return(nil)
+
+	err := svc.CreatePost(context.TODO(), create, oid.Hex())
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestPostService_CreatePost_BadId(t *testing.T) {
+	repo := new(mockPostRepo)
+	svc := &PostService{postRepo: repo}
+	err := svc.CreatePost(context.TODO(), &PostSchema.PostCreate{}, "bad")
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestPostService_ListPosts(t *testing.T) {
+	repo := new(mockPostRepo)
+	svc := &PostService{postRepo: repo}
+	query := &basemodel.BaseQuery{Skip: 0, Limit: 1}
+	oid := primitive.NewObjectID()
+	repo.On("ListPosts", mock.Anything, query).Return(int64(1), []PostModel.PostWithCreatorDocument{{Id: oid, Title: "t", Creator: UserModel.UserDocument{Id: oid, Username: "u"}}}, nil)
+
+	total, posts, err := svc.ListPosts(context.TODO(), query)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.Len(t, posts, 1)
+	assert.Equal(t, oid, posts[0].Id)
+	repo.AssertExpectations(t)
+}
+
+func TestPostService_GetPostById(t *testing.T) {
+	repo := new(mockPostRepo)
+	svc := &PostService{postRepo: repo}
+	oid := primitive.NewObjectID()
+	repo.On("GetPostById", mock.Anything, oid).Return(PostModel.PostWithCreatorDocument{PostDocument: PostModel.PostDocument{Id: oid, Title: "t", Content: ptr("c"), CreatedAt: time.Now()}, Creator: UserModel.UserDocument{Id: oid, Username: "u"}}, nil)
+
+	post, err := svc.GetPostById(context.TODO(), oid.Hex())
+	assert.NoError(t, err)
+	assert.Equal(t, oid, post.Id)
+	repo.AssertExpectations(t)
+}
+
+func TestPostService_GetPostById_BadId(t *testing.T) {
+	svc := &PostService{postRepo: new(mockPostRepo)}
+	_, err := svc.GetPostById(context.TODO(), "bad")
+	assert.Error(t, err)
+}
+
+func ptr(s string) *string { return &s }

--- a/app/utils/mongo/mongoutils/count_test.go
+++ b/app/utils/mongo/mongoutils/count_test.go
@@ -1,0 +1,53 @@
+package mongoutils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"wentee/blog/app/testutils"
+	"wentee/blog/app/utils/mongo/imongo"
+)
+
+type mockAggregator struct{ mock.Mock }
+
+func (m *mockAggregator) Aggregate(ctx context.Context, pipeline interface{}, opts ...*options.AggregateOptions) (imongo.Cursor, error) {
+	args := m.Called(append([]any{ctx, pipeline}, opts...)...)
+	return args.Get(0).(imongo.Cursor), args.Error(1)
+}
+
+func TestCountDocumentWithPipeline(t *testing.T) {
+	ctx := context.TODO()
+	pipeline := bson.A{bson.D{{Key: "stage", Value: 1}}}
+	cursor := new(testutils.MockCursor)
+	cursor.On("All", ctx, mock.Anything).Run(func(args mock.Arguments) {
+		out := args.Get(1).(*[]bson.M)
+		*out = []bson.M{{"total": int32(3)}}
+	}).Return(nil)
+	cursor.On("Close", ctx).Return(nil)
+
+	aggr := new(mockAggregator)
+	aggr.On("Aggregate", ctx, pipeline).Return(cursor, nil)
+
+	m := &MongoUtils{}
+	total, err := m.CountDocumentWithPipeline(ctx, aggr, pipeline)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(3), total)
+	cursor.AssertExpectations(t)
+	aggr.AssertExpectations(t)
+}
+
+func TestCountDocumentWithPipeline_Error(t *testing.T) {
+	ctx := context.TODO()
+	pipeline := bson.A{}
+	aggr := new(mockAggregator)
+	aggr.On("Aggregate", ctx, pipeline).Return((*testutils.MockCursor)(nil), assert.AnError)
+
+	m := &MongoUtils{}
+	total, err := m.CountDocumentWithPipeline(ctx, aggr, pipeline)
+	assert.Error(t, err)
+	assert.Equal(t, int64(0), total)
+}

--- a/app/utils/mongo/mongoutils/count_test.go
+++ b/app/utils/mongo/mongoutils/count_test.go
@@ -4,18 +4,19 @@ import (
 	"context"
 	"testing"
 
+	"wentee/blog/app/testutils"
+	"wentee/blog/app/utils/mongo/imongo"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"wentee/blog/app/testutils"
-	"wentee/blog/app/utils/mongo/imongo"
 )
 
 type mockAggregator struct{ mock.Mock }
 
 func (m *mockAggregator) Aggregate(ctx context.Context, pipeline interface{}, opts ...*options.AggregateOptions) (imongo.Cursor, error) {
-	args := m.Called(append([]any{ctx, pipeline}, opts...)...)
+	args := m.Called(testutils.AppendCallArgs([]any{ctx, pipeline}, opts)...)
 	return args.Get(0).(imongo.Cursor), args.Error(1)
 }
 

--- a/app/utils/mongo/pipefactory/pipeline_factory_test.go
+++ b/app/utils/mongo/pipefactory/pipeline_factory_test.go
@@ -1,0 +1,31 @@
+package pipefactory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestPipelineBuilder_Build(t *testing.T) {
+	pb := NewPipelineBuilder()
+	pb.AddOperations(
+		bson.D{{Key: "stage1", Value: "val1"}},
+		bson.D{{Key: "stage2", Value: "val2"}},
+	).AddSort(bson.D{{Key: "sort", Value: 1}}).AddSkip(5).AddLimit(10)
+
+	count := pb.BuildCountPipeline()
+	query := pb.BuildQeuryPipeline()
+
+	expectedStages := bson.A{
+		bson.D{{Key: "stage1", Value: "val1"}},
+		bson.D{{Key: "stage2", Value: "val2"}},
+	}
+
+	assert.Equal(t, append(expectedStages, bson.D{{Key: "$count", Value: "total"}}), count)
+	assert.Equal(t, append(expectedStages,
+		bson.D{{Key: "$sort", Value: bson.D{{Key: "sort", Value: 1}}}},
+		bson.D{{Key: "$skip", Value: int64(5)}},
+		bson.D{{Key: "$limit", Value: int64(10)}},
+	), query)
+}

--- a/app/utils/reqcontext/context_key_test.go
+++ b/app/utils/reqcontext/context_key_test.go
@@ -1,0 +1,48 @@
+package reqcontext
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	apperror "wentee/blog/app/schema/apperror"
+	"wentee/blog/app/schema/apperror/errcode"
+	AuthSchema "wentee/blog/app/schema/auth"
+)
+
+func TestGetUserInfo(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(nil)
+	want := AuthSchema.JWTUserInfo{Id: "123"}
+	c.Set(USER_INFO, want)
+
+	userInfo, err := GetUserInfo(c)
+	assert.NoError(t, err)
+	assert.Equal(t, want, userInfo)
+}
+
+func TestGetUserInfo_Missing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(nil)
+
+	_, err := GetUserInfo(c)
+	assert.Error(t, err)
+	if appErr, ok := err.(apperror.AppError); ok {
+		assert.Equal(t, errcode.USER_NOT_FOUND, appErr.Code)
+		assert.Equal(t, http.StatusBadRequest, appErr.Status)
+	}
+}
+
+func TestGetUserInfo_BadType(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(nil)
+	c.Set(USER_INFO, 1)
+
+	_, err := GetUserInfo(c)
+	assert.Error(t, err)
+	if appErr, ok := err.(apperror.AppError); ok {
+		assert.Equal(t, errcode.TYPE_ASSERTION_ERROR, appErr.Code)
+		assert.Equal(t, http.StatusInternalServerError, appErr.Status)
+	}
+}

--- a/app/utils/security_test.go
+++ b/app/utils/security_test.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPasswordUtils(t *testing.T) {
+	pu := &PasswordUtils{}
+	salt, err := pu.GenerateSalt(4)
+	assert.NoError(t, err)
+	assert.Len(t, salt, 8)
+
+	pwd := "secret"
+	hashed, err := pu.HashPassword(pwd, salt)
+	assert.NoError(t, err)
+	assert.True(t, pu.VerifyPassword(hashed, pwd, salt))
+	assert.False(t, pu.VerifyPassword(hashed, "bad", salt))
+}

--- a/coverReport.html
+++ b/coverReport.html
@@ -57,7 +57,7 @@
 				
 				<option value="file0">wentee/blog/app/appinit/mongo.go (0.0%)</option>
 				
-				<option value="file1">wentee/blog/app/config/environment.go (0.0%)</option>
+				<option value="file1">wentee/blog/app/config/environment.go (100.0%)</option>
 				
 				<option value="file2">wentee/blog/app/di/container.go (0.0%)</option>
 				
@@ -99,9 +99,9 @@
 				
 				<option value="file21">wentee/blog/app/schema/basemodel/base.go (0.0%)</option>
 				
-				<option value="file22">wentee/blog/app/services/auth/auth.go (0.0%)</option>
+				<option value="file22">wentee/blog/app/services/auth/auth.go (81.8%)</option>
 				
-				<option value="file23">wentee/blog/app/services/post/post_impl.go (0.0%)</option>
+				<option value="file23">wentee/blog/app/services/post/post_impl.go (58.6%)</option>
 				
 				<option value="file24">wentee/blog/app/services/user/user_impl.go (55.6%)</option>
 				
@@ -109,13 +109,13 @@
 				
 				<option value="file26">wentee/blog/app/testutils/password_utils.go (0.0%)</option>
 				
-				<option value="file27">wentee/blog/app/utils/mongo/mongoutils/count.go (0.0%)</option>
+				<option value="file27">wentee/blog/app/utils/mongo/mongoutils/count.go (81.8%)</option>
 				
-				<option value="file28">wentee/blog/app/utils/mongo/pipefactory/pipeline_factory.go (0.0%)</option>
+				<option value="file28">wentee/blog/app/utils/mongo/pipefactory/pipeline_factory.go (100.0%)</option>
 				
-				<option value="file29">wentee/blog/app/utils/reqcontext/context_key.go (0.0%)</option>
+				<option value="file29">wentee/blog/app/utils/reqcontext/context_key.go (100.0%)</option>
 				
-				<option value="file30">wentee/blog/app/utils/security.go (0.0%)</option>
+				<option value="file30">wentee/blog/app/utils/security.go (90.9%)</option>
 				
 				</select>
 			</div>
@@ -164,20 +164,20 @@ var (
         JWT_SECRET     string
 )
 
-func init() <span class="cov0" title="0">{
+func init() <span class="cov8" title="1">{
         SERVICE_NAME = getEnvOrDefault("SERVICE_NAME", "App")
         MONGO_URI = getEnvOrDefault("MONGO_URI", "mongodb://localhost:27017")
         MOGNO_DATABASE = getEnvOrDefault("MOGNO_DATABASE", "Blog_Default")
         JWT_SECRET = getEnvOrDefault("JWT_SECRET", "RadomString")
 }</span>
 
-func getEnvOrDefault(env_key, default_value string) string <span class="cov0" title="0">{
+func getEnvOrDefault(env_key, default_value string) string <span class="cov8" title="1">{
 
-        if v := os.Getenv(env_key); v != "" </span><span class="cov0" title="0">{
+        if v := os.Getenv(env_key); v != "" </span><span class="cov8" title="1">{
                 return v
         }</span>
 
-        <span class="cov0" title="0">return default_value</span>
+        <span class="cov8" title="1">return default_value</span>
 }
 </pre>
 		
@@ -1926,7 +1926,7 @@ func (e *AppError) RawErr() error <span class="cov0" title="0">{
 		<pre class="file" id="file20" style="display: none">package errcode
 
 const (
-        TPYE_ASSERTION_ERROR = "TYPE_ASSETION_ERROR"
+        TYPE_ASSERTION_ERROR = "TYPE_ASSERTION_ERROR"
         USER_EXIST           = "USER_EXIST"
         USER_NOT_FOUND       = "USER_NOT_FOUND"
         INVALID_TOKEN        = "INVALID_TOKEN"
@@ -1940,7 +1940,7 @@ var code2Message = map[string]string{
         INVALID_TOKEN:        "Token 驗證失敗",
         EXPIRED_TOKEN:        "Token 過期",
         BAD_REQUEST:          "輸入錯誤",
-        TPYE_ASSERTION_ERROR: "內部推斷型態錯誤",
+        TYPE_ASSERTION_ERROR: "內部推斷型態錯誤",
 }
 
 func Message(code string) string <span class="cov0" title="0">{
@@ -1995,17 +1995,17 @@ import (
 
 type AuthService struct {
         userRepo      UserRepo.IGetUserByMail
-        passwordUtils utils.IPasswrodUtils
+        passwordUtils utils.IPasswordUtils
 }
 
-func NewAuthService(userRepo *UserRepo.UserRepo, passwordUtils utils.IPasswrodUtils) *AuthService <span class="cov0" title="0">{
+func NewAuthService(userRepo *UserRepo.UserRepo, passwordUtils utils.IPasswordUtils) *AuthService <span class="cov0" title="0">{
         return &amp;AuthService{
                 userRepo:      userRepo,
                 passwordUtils: passwordUtils,
         }
 }</span>
 
-func (authSvc *AuthService) TryLogin(ctx context.Context, loginInfo *AuthSchema.LoginInfo) (tokenString string, err error) <span class="cov0" title="0">{
+func (authSvc *AuthService) TryLogin(ctx context.Context, loginInfo *AuthSchema.LoginInfo) (tokenString string, err error) <span class="cov8" title="1">{
 
         userDoc, err := authSvc.userRepo.GetUserByEmail(ctx, loginInfo.Email)
 
@@ -2013,12 +2013,12 @@ func (authSvc *AuthService) TryLogin(ctx context.Context, loginInfo *AuthSchema.
                 return
         }</span>
 
-        <span class="cov0" title="0">if !authSvc.passwordUtils.VerifyPassword(userDoc.Password, loginInfo.Password, userDoc.Salt) </span><span class="cov0" title="0">{
+        <span class="cov8" title="1">if !authSvc.passwordUtils.VerifyPassword(userDoc.Password, loginInfo.Password, userDoc.Salt) </span><span class="cov8" title="1">{
                 err = apperror.New(http.StatusNotFound, errcode.USER_NOT_FOUND, nil)
                 return
         }</span>
 
-        <span class="cov0" title="0">claims := AuthSchema.JWTClaims{
+        <span class="cov8" title="1">claims := AuthSchema.JWTClaims{
                 UserInfo: AuthSchema.JWTUserInfo{
                         Id: userDoc.Id.Hex(),
                 },
@@ -2057,21 +2057,21 @@ func NewPostService(postRepo *PostRepo.PostRepo) *PostService <span class="cov0"
         }
 }</span>
 
-func (svc *PostService) CreatePost(ctx context.Context, postCreate *PostSchema.PostCreate, createdByString string) (err error) <span class="cov0" title="0">{
+func (svc *PostService) CreatePost(ctx context.Context, postCreate *PostSchema.PostCreate, createdByString string) (err error) <span class="cov8" title="1">{
         createdBy, err := primitive.ObjectIDFromHex(createdByString)
-        if err != nil </span><span class="cov0" title="0">{
+        if err != nil </span><span class="cov8" title="1">{
                 return
         }</span>
-        <span class="cov0" title="0">err = svc.postRepo.CreatePost(ctx, postCreate, &amp;createdBy)
+        <span class="cov8" title="1">err = svc.postRepo.CreatePost(ctx, postCreate, &amp;createdBy)
         return</span>
 }
 
-func (svc *PostService) ListPosts(ctx context.Context, query *basemodel.BaseQuery) (total int64, postSlice []PostSchema.PostList, err error) <span class="cov0" title="0">{
+func (svc *PostService) ListPosts(ctx context.Context, query *basemodel.BaseQuery) (total int64, postSlice []PostSchema.PostList, err error) <span class="cov8" title="1">{
         total, posts, err := svc.postRepo.ListPosts(ctx, query)
 
         postSlice = make([]PostSchema.PostList, len(posts))
 
-        for index, post := range posts </span><span class="cov0" title="0">{
+        for index, post := range posts </span><span class="cov8" title="1">{
                 postSlice[index] = PostSchema.PostList{
                         Id:      post.Id,
                         Title:   post.Title,
@@ -2079,20 +2079,20 @@ func (svc *PostService) ListPosts(ctx context.Context, query *basemodel.BaseQuer
                 }
         }</span>
 
-        <span class="cov0" title="0">return</span>
+        <span class="cov8" title="1">return</span>
 }
 
-func (svc *PostService) GetPostById(ctx context.Context, id string) (post PostSchema.Post, err error) <span class="cov0" title="0">{
+func (svc *PostService) GetPostById(ctx context.Context, id string) (post PostSchema.Post, err error) <span class="cov8" title="1">{
         oid, err := primitive.ObjectIDFromHex(id)
 
+        if err != nil </span><span class="cov8" title="1">{
+                return
+        }</span>
+        <span class="cov8" title="1">postDoc, err := svc.postRepo.GetPostById(ctx, oid)
         if err != nil </span><span class="cov0" title="0">{
                 return
         }</span>
-        <span class="cov0" title="0">postDoc, err := svc.postRepo.GetPostById(ctx, oid)
-        if err != nil </span><span class="cov0" title="0">{
-                return
-        }</span>
-        <span class="cov0" title="0">post = PostSchema.Post{
+        <span class="cov8" title="1">post = PostSchema.Post{
                 PostList: PostSchema.PostList{
                         Id:      postDoc.Id,
                         Title:   postDoc.Title,
@@ -2146,11 +2146,11 @@ import (
 
 type UserService struct {
         userRepo      UserRepo.IUserRepository
-        passwordUtils utils.IPasswrodUtils
+        passwordUtils utils.IPasswordUtils
         objectCreator imongo.IObjectIdCreator
 }
 
-func NewUserService(userRepo UserRepo.IUserRepository, passwordUtils utils.IPasswrodUtils, objectCreator imongo.IObjectIdCreator) *UserService <span class="cov8" title="1">{
+func NewUserService(userRepo UserRepo.IUserRepository, passwordUtils utils.IPasswordUtils, objectCreator imongo.IObjectIdCreator) *UserService <span class="cov8" title="1">{
         return &amp;UserService{
                 userRepo:      userRepo,
                 passwordUtils: passwordUtils,
@@ -2383,20 +2383,20 @@ type MockPasswordUtils struct {
         mock.Mock
 }
 
-// GenerateSalt implements utils.IPasswrodUtils.
+// GenerateSalt implements utils.IPasswordUtils.
 func (m *MockPasswordUtils) GenerateSalt(length int) (string, error) <span class="cov0" title="0">{
         args := m.Called(length)
 
         return args.String(0), args.Error(1)
 }</span>
 
-// HashPassword implements utils.IPasswrodUtils.
+// HashPassword implements utils.IPasswordUtils.
 func (m *MockPasswordUtils) HashPassword(password string, salt string) (string, error) <span class="cov0" title="0">{
         args := m.Called(password, salt)
         return args.String(0), args.Error(1)
 }</span>
 
-// VerifyPassword implements utils.IPasswrodUtils.
+// VerifyPassword implements utils.IPasswordUtils.
 func (m *MockPasswordUtils) VerifyPassword(hashedPassword string, password string, salt string) bool <span class="cov0" title="0">{
         args := m.Called(hashedPassword, password, salt)
         return args.Bool(0)
@@ -2420,23 +2420,23 @@ type DocumentCounter interface {
 type MongoUtils struct {
 }
 
-func (m *MongoUtils) CountDocumentWithPipeline(ctx context.Context, aggregator imongo.IAggregate, countPipeline bson.A) (total int64, err error) <span class="cov0" title="0">{
+func (m *MongoUtils) CountDocumentWithPipeline(ctx context.Context, aggregator imongo.IAggregate, countPipeline bson.A) (total int64, err error) <span class="cov8" title="1">{
         cursor, err := aggregator.Aggregate(ctx, countPipeline)
 
-        if err != nil </span><span class="cov0" title="0">{
+        if err != nil </span><span class="cov8" title="1">{
                 return
         }</span>
-        <span class="cov0" title="0">defer cursor.Close(ctx)
+        <span class="cov8" title="1">defer cursor.Close(ctx)
 
         var countResult []bson.M
         if err = cursor.All(ctx, &amp;countResult); err != nil </span><span class="cov0" title="0">{
                 return
         }</span>
 
-        <span class="cov0" title="0">if len(countResult) &gt; 0 </span><span class="cov0" title="0">{
+        <span class="cov8" title="1">if len(countResult) &gt; 0 </span><span class="cov8" title="1">{
                 total = int64(countResult[0]["total"].(int32))
         }</span>
-        <span class="cov0" title="0">return</span>
+        <span class="cov8" title="1">return</span>
 }
 
 type ObjectIdCreator struct {
@@ -2461,33 +2461,33 @@ type PipelineBuilder struct {
         limit     *int64
 }
 
-func NewPipelineBuilder() *PipelineBuilder <span class="cov0" title="0">{
+func NewPipelineBuilder() *PipelineBuilder <span class="cov8" title="1">{
         return &amp;PipelineBuilder{}
 }</span>
 
-func (pb *PipelineBuilder) AddOperations(ops ...bson.D) *PipelineBuilder <span class="cov0" title="0">{
-        for _, op := range ops </span><span class="cov0" title="0">{
+func (pb *PipelineBuilder) AddOperations(ops ...bson.D) *PipelineBuilder <span class="cov8" title="1">{
+        for _, op := range ops </span><span class="cov8" title="1">{
                 pb.stages = append(pb.stages, op)
         }</span>
-        <span class="cov0" title="0">return pb</span>
+        <span class="cov8" title="1">return pb</span>
 }
 
-func (pb *PipelineBuilder) AddSkip(skip int64) *PipelineBuilder <span class="cov0" title="0">{
+func (pb *PipelineBuilder) AddSkip(skip int64) *PipelineBuilder <span class="cov8" title="1">{
         pb.skip = &amp;skip
         return pb
 }</span>
 
-func (pb *PipelineBuilder) AddLimit(limit int64) *PipelineBuilder <span class="cov0" title="0">{
+func (pb *PipelineBuilder) AddLimit(limit int64) *PipelineBuilder <span class="cov8" title="1">{
         pb.limit = &amp;limit
         return pb
 }</span>
 
-func (pb *PipelineBuilder) AddSort(sort bson.D) *PipelineBuilder <span class="cov0" title="0">{
+func (pb *PipelineBuilder) AddSort(sort bson.D) *PipelineBuilder <span class="cov8" title="1">{
         pb.sortStage = sort
         return pb
 }</span>
 
-func (pb *PipelineBuilder) BuildCountPipeline() bson.A <span class="cov0" title="0">{
+func (pb *PipelineBuilder) BuildCountPipeline() bson.A <span class="cov8" title="1">{
         pipeline := bson.A{}
         pipeline = append(pipeline, pb.stages...)
         pipeline = append(pipeline, bson.D{{Key: "$count", Value: "total"}})
@@ -2495,21 +2495,21 @@ func (pb *PipelineBuilder) BuildCountPipeline() bson.A <span class="cov0" title=
 
 }</span>
 
-func (pb *PipelineBuilder) BuildQeuryPipeline() bson.A <span class="cov0" title="0">{
+func (pb *PipelineBuilder) BuildQeuryPipeline() bson.A <span class="cov8" title="1">{
         pipeline := bson.A{}
         pipeline = append(pipeline, pb.stages...)
 
-        if len(pb.sortStage) &gt; 0 </span><span class="cov0" title="0">{
+        if len(pb.sortStage) &gt; 0 </span><span class="cov8" title="1">{
                 pipeline = append(pipeline, bson.D{{Key: "$sort", Value: pb.sortStage}})
         }</span>
-        <span class="cov0" title="0">if pb.skip != nil </span><span class="cov0" title="0">{
+        <span class="cov8" title="1">if pb.skip != nil </span><span class="cov8" title="1">{
                 pipeline = append(pipeline, bson.D{{Key: "$skip", Value: *pb.skip}})
         }</span>
-        <span class="cov0" title="0">if pb.limit != nil </span><span class="cov0" title="0">{
+        <span class="cov8" title="1">if pb.limit != nil </span><span class="cov8" title="1">{
                 pipeline = append(pipeline, bson.D{{Key: "$limit", Value: *pb.limit}})
         }</span>
 
-        <span class="cov0" title="0">return pipeline</span>
+        <span class="cov8" title="1">return pipeline</span>
 }
 </pre>
 		
@@ -2519,7 +2519,6 @@ import (
         "net/http"
         "wentee/blog/app/schema/apperror"
         "wentee/blog/app/schema/apperror/errcode"
-        "wentee/blog/app/schema/auth"
         AuthSchema "wentee/blog/app/schema/auth"
 
         "github.com/gin-gonic/gin"
@@ -2527,18 +2526,18 @@ import (
 
 const USER_INFO = "UserInfo"
 
-func GetUserInfo(c *gin.Context) (userInfo AuthSchema.JWTUserInfo, err error) <span class="cov0" title="0">{
+func GetUserInfo(c *gin.Context) (userInfo AuthSchema.JWTUserInfo, err error) <span class="cov8" title="1">{
         userInfoAny, ok := c.Get(USER_INFO)
-        if !ok </span><span class="cov0" title="0">{
+        if !ok </span><span class="cov8" title="1">{
                 err = apperror.New(http.StatusBadRequest, errcode.USER_NOT_FOUND, nil)
                 return
         }</span>
-        <span class="cov0" title="0">userInfo, ok = userInfoAny.(auth.JWTUserInfo)
-        if !ok </span><span class="cov0" title="0">{
-                err = apperror.New(http.StatusInternalServerError, errcode.TPYE_ASSERTION_ERROR, nil)
+        <span class="cov8" title="1">userInfo, ok = userInfoAny.(AuthSchema.JWTUserInfo)
+        if !ok </span><span class="cov8" title="1">{
+                err = apperror.New(http.StatusInternalServerError, errcode.TYPE_ASSERTION_ERROR, nil)
                 return
         }</span>
-        <span class="cov0" title="0">return</span>
+        <span class="cov8" title="1">return</span>
 }
 </pre>
 		
@@ -2551,7 +2550,7 @@ import (
         "golang.org/x/crypto/bcrypt"
 )
 
-type IPasswrodUtils interface {
+type IPasswordUtils interface {
         GenerateSalt(length int) (string, error)
         HashPassword(password string, salt string) (string, error)
         VerifyPassword(hashedPassword string, password string, salt string) bool
@@ -2560,30 +2559,30 @@ type IPasswrodUtils interface {
 type PasswordUtils struct {
 }
 
-func (pu *PasswordUtils) GenerateSalt(length int) (string, error) <span class="cov0" title="0">{
+func (pu *PasswordUtils) GenerateSalt(length int) (string, error) <span class="cov8" title="1">{
         placeBytes := make([]byte, length)
 
         if _, err := rand.Read(placeBytes); err != nil </span><span class="cov0" title="0">{
                 return "", err
         }</span>
 
-        <span class="cov0" title="0">return hex.EncodeToString(placeBytes), nil</span>
+        <span class="cov8" title="1">return hex.EncodeToString(placeBytes), nil</span>
 }
 
-func (pu *PasswordUtils) HashPassword(password string, salt string) (string, error) <span class="cov0" title="0">{
+func (pu *PasswordUtils) HashPassword(password string, salt string) (string, error) <span class="cov8" title="1">{
         salted := password + salt
         hashBytes, err := bcrypt.GenerateFromPassword([]byte(salted), bcrypt.DefaultCost)
 
         return string(hashBytes), err
 }</span>
 
-func (pu *PasswordUtils) VerifyPassword(hashedPassword string, password string, salt string) bool <span class="cov0" title="0">{
+func (pu *PasswordUtils) VerifyPassword(hashedPassword string, password string, salt string) bool <span class="cov8" title="1">{
         salted := password + salt
 
-        if err := bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(salted)); err != nil </span><span class="cov0" title="0">{
+        if err := bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(salted)); err != nil </span><span class="cov8" title="1">{
                 return false
         }</span>
-        <span class="cov0" title="0">return true</span>
+        <span class="cov8" title="1">return true</span>
 }
 </pre>
 		


### PR DESCRIPTION
## Summary
- add unit tests for pipeline builder and mongo utils
- add tests for context utilities, password utils and env config
- cover post and auth services with basic tests

## Testing
- `go vet ./...` *(fails: proxy blocked)*
- `go test ./...` *(fails: proxy blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687b0f18cf188329abf4bfd1feb5638e