### PR TITLE
Add tests for security utilities and pipeline builder

### DIFF
--- a/app/utils/mongo/pipefactory/pipeline_factory_test.go
+++ b/app/utils/mongo/pipefactory/pipeline_factory_test.go
@@ -29,3 +29,30 @@ func TestPipelineBuilder_Build(t *testing.T) {
 		bson.D{{Key: "$limit", Value: int64(10)}},
 	), query)
 }
+
+func TestPipelineBuilder_NoOptions(t *testing.T) {
+	pb := NewPipelineBuilder()
+	pb.AddOperations(bson.D{{Key: "only", Value: 1}})
+	count := pb.BuildCountPipeline()
+	query := pb.BuildQeuryPipeline()
+
+	expected := bson.A{bson.D{{Key: "only", Value: 1}}}
+
+	assert.Equal(t, append(expected, bson.D{{Key: "$count", Value: "total"}}), count)
+	assert.Equal(t, expected, query)
+}
+
+func TestPipelineBuilder_WithSkipLimitSort(t *testing.T) {
+	pb := NewPipelineBuilder()
+	pb.AddOperations(bson.D{{Key: "s1", Value: "val"}}).
+		AddSkip(3).AddLimit(6).AddSort(bson.D{{Key: "sort", Value: -1}})
+
+	query := pb.BuildQeuryPipeline()
+
+	assert.Equal(t, bson.A{
+		bson.D{{Key: "s1", Value: "val"}},
+		bson.D{{Key: "$sort", Value: bson.D{{Key: "sort", Value: -1}}}},
+		bson.D{{Key: "$skip", Value: int64(3)}},
+		bson.D{{Key: "$limit", Value: int64(6)}},
+	}, query)
+}

--- a/app/utils/security_test.go
+++ b/app/utils/security_test.go
@@ -18,3 +18,26 @@ func TestPasswordUtils(t *testing.T) {
 	assert.True(t, pu.VerifyPassword(hashed, pwd, salt))
 	assert.False(t, pu.VerifyPassword(hashed, "bad", salt))
 }
+
+func TestGenerateSaltUnique(t *testing.T) {
+	pu := &PasswordUtils{}
+	s1, err1 := pu.GenerateSalt(4)
+	s2, err2 := pu.GenerateSalt(4)
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+	assert.Len(t, s1, 8)
+	assert.Len(t, s2, 8)
+	assert.NotEqual(t, s1, s2)
+}
+
+func TestHashAndVerifyPassword(t *testing.T) {
+	pu := &PasswordUtils{}
+	salt, _ := pu.GenerateSalt(4)
+	pwd := "secret"
+	hashed, err := pu.HashPassword(pwd, salt)
+	assert.NoError(t, err)
+	assert.NotEqual(t, pwd, hashed)
+	assert.True(t, pu.VerifyPassword(hashed, pwd, salt))
+	assert.False(t, pu.VerifyPassword(hashed, "wrong", salt))
+	assert.False(t, pu.VerifyPassword(hashed, pwd, salt+"1"))
+}


### PR DESCRIPTION
## Summary
- expand security utilities tests to check unique salt generation and password verification
- add tests for PipelineBuilder covering optional stages

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687b2dd7e188832989fb0b3aa5850573