### PR TITLE
Add middleware tests

### DIFF
--- a/app/middleware/auth_test.go
+++ b/app/middleware/auth_test.go
@@ -1,0 +1,81 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"wentee/blog/app/config"
+	"wentee/blog/app/schema/apperror/errcode"
+	AuthSchema "wentee/blog/app/schema/auth"
+	"wentee/blog/app/utils/reqcontext"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+)
+
+func generateToken(exp time.Time) string {
+	claims := AuthSchema.JWTClaims{
+		UserInfo: AuthSchema.JWTUserInfo{Id: "123"},
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    config.SERVICE_NAME,
+			ExpiresAt: jwt.NewNumericDate(exp),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenStr, _ := token.SignedString([]byte(config.JWT_SECRET))
+	return tokenStr
+}
+
+func TestRequiredAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	authMw := AuthMiddleware{}
+
+	router := gin.New()
+	router.Use(ErrorHandler())
+	router.Use(authMw.RequiredAuth())
+
+	var gotUser AuthSchema.JWTUserInfo
+	router.GET("/", func(c *gin.Context) {
+		val, _ := reqcontext.GetUserInfo(c)
+		gotUser = val
+		c.Status(http.StatusOK)
+	})
+
+	t.Run("ValidToken", func(t *testing.T) {
+		token := generateToken(time.Now().Add(time.Hour))
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Authorization", token)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "123", gotUser.Id)
+	})
+
+	t.Run("MissingToken", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.Contains(t, w.Body.String(), errcode.INVALID_TOKEN)
+	})
+
+	t.Run("ExpiredToken", func(t *testing.T) {
+		token := generateToken(time.Now().Add(-time.Hour))
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Authorization", token)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.Contains(t, w.Body.String(), errcode.EXPIRED_TOKEN)
+	})
+}

--- a/app/middleware/error_test.go
+++ b/app/middleware/error_test.go
@@ -1,0 +1,57 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"wentee/blog/app/schema/apperror"
+	"wentee/blog/app/schema/apperror/errcode"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
+	"github.com/stretchr/testify/assert"
+)
+
+type testPayload struct {
+	Name string `validate:"required"`
+}
+
+func TestErrorHandler_AppError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(ErrorHandler())
+	router.GET("/", func(c *gin.Context) {
+		c.Error(apperror.New(http.StatusBadRequest, errcode.BAD_REQUEST, nil))
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	router.ServeHTTP(w, req)
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, errcode.BAD_REQUEST, resp["Code"])
+}
+
+func TestErrorHandler_ValidationErrors(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(ErrorHandler())
+	validate := validator.New()
+
+	router.GET("/", func(c *gin.Context) {
+		var p testPayload
+		err := validate.Struct(p)
+		c.Error(err)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}


### PR DESCRIPTION
## Summary
- add tests for auth middleware covering valid, missing, and expired token cases
- add tests for error middleware verifying AppError and validation error handling

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687b2dc396e483298512ff544c0f5e7a