### PR TITLE
Add route registration tests

### DIFF
--- a/app/routes/routes_test.go
+++ b/app/routes/routes_test.go
@@ -1,0 +1,47 @@
+package routes_test
+
+import (
+	"github.com/gin-gonic/gin"
+	"testing"
+	"wentee/blog/app/di"
+	AuthRouter "wentee/blog/app/handler/auth"
+	PostRouter "wentee/blog/app/handler/post"
+	UserRouter "wentee/blog/app/handler/user"
+	"wentee/blog/app/routes"
+)
+
+func TestSetupRouter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c := &di.Container{
+		UserRouter: &UserRouter.UserRouter{},
+		AuthRouter: &AuthRouter.AuthRouter{},
+		PostRouter: &PostRouter.PostRouter{},
+	}
+
+	r := routes.SetupRouter(c)
+
+	if got := len(r.Handlers); got != 3 {
+		t.Fatalf("expected 3 global middlewares, got %d", got)
+	}
+
+	expected := map[string]bool{
+		"/auth/login": false,
+		"/users":      false,
+		"/users/me":   false,
+		"/users/:id":  false,
+		"/posts":      false,
+		"/posts/:id":  false,
+	}
+
+	for _, info := range r.Routes() {
+		if _, ok := expected[info.Path]; ok {
+			expected[info.Path] = true
+		}
+	}
+
+	for p, ok := range expected {
+		if !ok {
+			t.Errorf("route %s not registered", p)
+		}
+	}
+}

--- a/app/routes/v1/auth_test.go
+++ b/app/routes/v1/auth_test.go
@@ -1,0 +1,35 @@
+package v1_test
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"wentee/blog/app/di"
+	AuthRouter "wentee/blog/app/handler/auth"
+	v1 "wentee/blog/app/routes/v1"
+)
+
+func TestRegistryAuthRouter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	c := &di.Container{AuthRouter: &AuthRouter.AuthRouter{}}
+
+	v1.RegistryAuthRouter(r.Group("/auth"), c)
+
+	expected := gin.RouteInfo{
+		Method:  "POST",
+		Path:    "/auth/login",
+		Handler: handlerName(c.AuthRouter.Login),
+	}
+
+	found := false
+	for _, rt := range r.Routes() {
+		if rt.Method == expected.Method && rt.Path == expected.Path && rt.Handler == expected.Handler {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected route %+v registered", expected)
+	}
+}

--- a/app/routes/v1/helper_test.go
+++ b/app/routes/v1/helper_test.go
@@ -1,0 +1,10 @@
+package v1_test
+
+import (
+	"reflect"
+	"runtime"
+)
+
+func handlerName(f any) string {
+	return runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
+}

--- a/app/routes/v1/post_test.go
+++ b/app/routes/v1/post_test.go
@@ -1,0 +1,39 @@
+package v1_test
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"wentee/blog/app/di"
+	PostRouter "wentee/blog/app/handler/post"
+	v1 "wentee/blog/app/routes/v1"
+)
+
+func TestRegistryPostRouter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	c := &di.Container{PostRouter: &PostRouter.PostRouter{}}
+
+	v1.RegistryPostRouter(r.Group("/posts"), c)
+
+	checks := []gin.RouteInfo{
+		{Method: "POST", Path: "/posts", Handler: handlerName(c.PostRouter.CreatePost)},
+		{Method: "GET", Path: "/posts", Handler: handlerName(c.PostRouter.ListPosts)},
+		{Method: "GET", Path: "/posts/:id", Handler: handlerName(c.PostRouter.GetPost)},
+		{Method: "PATCH", Path: "/posts/:id", Handler: handlerName(c.PostRouter.UpdatePost)},
+		{Method: "DELETE", Path: "/posts/:id", Handler: handlerName(c.PostRouter.DeletePost)},
+	}
+
+	for _, exp := range checks {
+		found := false
+		for _, rt := range r.Routes() {
+			if rt.Method == exp.Method && rt.Path == exp.Path && rt.Handler == exp.Handler {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected route %+v registered", exp)
+		}
+	}
+}

--- a/app/routes/v1/user_test.go
+++ b/app/routes/v1/user_test.go
@@ -1,0 +1,40 @@
+package v1_test
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"wentee/blog/app/di"
+	UserRouter "wentee/blog/app/handler/user"
+	v1 "wentee/blog/app/routes/v1"
+)
+
+func TestRegistryUserRouter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	c := &di.Container{UserRouter: &UserRouter.UserRouter{}}
+
+	v1.RegistryUserRouter(r.Group("/users"), c)
+
+	checks := []gin.RouteInfo{
+		{Method: "POST", Path: "/users", Handler: handlerName(c.UserRouter.CreateUser)},
+		{Method: "GET", Path: "/users", Handler: handlerName(c.UserRouter.ListUsers)},
+		{Method: "GET", Path: "/users/me", Handler: handlerName(c.UserRouter.GetMe)},
+		{Method: "GET", Path: "/users/:id", Handler: handlerName(c.UserRouter.GetUser)},
+		{Method: "PATCH", Path: "/users/:id", Handler: handlerName(c.UserRouter.UpdateUser)},
+		{Method: "DELETE", Path: "/users/:id", Handler: handlerName(c.UserRouter.DeleteUser)},
+	}
+
+	for _, exp := range checks {
+		found := false
+		for _, rt := range r.Routes() {
+			if rt.Method == exp.Method && rt.Path == exp.Path && rt.Handler == exp.Handler {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected route %+v registered", exp)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- test global router setup for middleware and sub routers
- verify each v1 router registers expected handlers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c686cf468832983e53c9102c2c07d