### PR TITLE
Add tests for Mongo client initialization

### DIFF
--- a/app/appinit/mongo.go
+++ b/app/appinit/mongo.go
@@ -8,11 +8,15 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+// mongoConnect is used to establish the connection to MongoDB. It is defined as
+// a variable so it can be replaced in tests.
+var mongoConnect = mongo.Connect
+
 func GetMongoClient(opt *options.ClientOptions) *mongo.Client {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	client, err := mongo.Connect(ctx, opt)
+	client, err := mongoConnect(ctx, opt)
 
 	if err != nil {
 		panic("Mongo Connection Error!")

--- a/app/appinit/mongo_test.go
+++ b/app/appinit/mongo_test.go
@@ -1,0 +1,35 @@
+package appinit
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func TestGetMongoClientSuccess(t *testing.T) {
+	expected := &mongo.Client{}
+	old := mongoConnect
+	mongoConnect = func(ctx context.Context, opts ...*options.ClientOptions) (*mongo.Client, error) {
+		return expected, nil
+	}
+	defer func() { mongoConnect = old }()
+
+	client := GetMongoClient(options.Client())
+	assert.Equal(t, expected, client)
+}
+
+func TestGetMongoClientError(t *testing.T) {
+	old := mongoConnect
+	mongoConnect = func(ctx context.Context, opts ...*options.ClientOptions) (*mongo.Client, error) {
+		return nil, errors.New("fail")
+	}
+	defer func() { mongoConnect = old }()
+
+	assert.PanicsWithValue(t, "Mongo Connection Error!", func() {
+		GetMongoClient(options.Client())
+	})
+}


### PR DESCRIPTION
## Summary
- make Mongo connect function swappable for testing
- add tests covering successful and failing Mongo connection scenarios

## Testing
- `go test ./app/appinit -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687c687455ac8329a736ae25caf7c7fc