### PR TITLE
Add tests for error handling and base query defaults

### DIFF
--- a/app/schema/apperror/apperror_test.go
+++ b/app/schema/apperror/apperror_test.go
@@ -1,0 +1,25 @@
+package apperror
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"wentee/blog/app/schema/apperror/errcode"
+)
+
+func TestNewAndMethods(t *testing.T) {
+	raw := errors.New("raw")
+	ae := New(http.StatusBadRequest, errcode.BAD_REQUEST, raw)
+
+	assert.Equal(t, http.StatusBadRequest, ae.Status)
+	assert.Equal(t, errcode.BAD_REQUEST, ae.Code)
+	assert.Equal(t, raw, ae.RawErr())
+	// Message field should be empty by default
+	assert.Empty(t, ae.Message)
+
+	// GetMessage should return the mapping from errcode
+	assert.Equal(t, errcode.Message(errcode.BAD_REQUEST), ae.GetMessage())
+}

--- a/app/schema/apperror/errcode/error_code_test.go
+++ b/app/schema/apperror/errcode/error_code_test.go
@@ -1,0 +1,13 @@
+package errcode
+
+import "testing"
+
+func TestMessage(t *testing.T) {
+	if msg := Message(USER_NOT_FOUND); msg != "使用者不存在" {
+		t.Errorf("unexpected message: %s", msg)
+	}
+
+	if msg := Message("UNKNOWN"); msg != "未定義錯誤" {
+		t.Errorf("unexpected message for unknown code: %s", msg)
+	}
+}

--- a/app/schema/basemodel/base_test.go
+++ b/app/schema/basemodel/base_test.go
@@ -1,0 +1,10 @@
+package basemodel
+
+import "testing"
+
+func TestNewDefaultQuery(t *testing.T) {
+	q := NewDefaultQuery()
+	if q.Skip != 0 || q.Limit != 10 {
+		t.Fatalf("unexpected defaults: %+v", q)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for apperror constructors and helpers
- test errcode message mapping
- verify NewDefaultQuery defaults

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687c685f66dc8329a50d767ee5471e8d