### PR TITLE
Add additional service tests

### DIFF
--- a/app/services/post/post_test.go
+++ b/app/services/post/post_test.go
@@ -102,4 +102,43 @@ func TestPostService_GetPostById_BadId(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestPostService_UpdatePostById(t *testing.T) {
+	repo := new(mockPostRepo)
+	svc := &PostService{postRepo: repo}
+	oid := primitive.NewObjectID()
+	updateData := &PostSchema.PostUpdate{Title: ptr("new")}
+	repo.On("UpdatePostById", mock.Anything, oid, updateData).Return(nil)
+
+	err := svc.UpdatePostById(context.TODO(), oid.Hex(), updateData)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestPostService_UpdatePostById_BadId(t *testing.T) {
+	repo := new(mockPostRepo)
+	svc := &PostService{postRepo: repo}
+	err := svc.UpdatePostById(context.TODO(), "bad", &PostSchema.PostUpdate{})
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestPostService_DeletePostById(t *testing.T) {
+	repo := new(mockPostRepo)
+	svc := &PostService{postRepo: repo}
+	oid := primitive.NewObjectID()
+	repo.On("DeletePostById", mock.Anything, oid).Return(nil)
+
+	err := svc.DeletePostById(context.TODO(), oid.Hex())
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestPostService_DeletePostById_BadId(t *testing.T) {
+	repo := new(mockPostRepo)
+	svc := &PostService{postRepo: repo}
+	err := svc.DeletePostById(context.TODO(), "bad")
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
 func ptr(s string) *string { return &s }


### PR DESCRIPTION
## Summary
- expand post service tests to cover update and delete logic
- broaden user service tests with list, update, and delete scenarios

## Testing
- `go test ./...` *(fails: proxy blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687c685c26088329bb994ba10e5dca5d